### PR TITLE
Fix typo in neurodamus installation

### DIFF
--- a/install_neurodamus.sh
+++ b/install_neurodamus.sh
@@ -284,7 +284,9 @@ if [[ ! -e neurodamus ]]; then
         git clone https://github.com/openbraininstitute/neurodamus.git --depth 1 -b $NEURODAMUS_TAG
     fi
 fi
-uv pip install neurodamus
+cd neurodamus
+uv pip install .
+cd ..
 
 export PATH="$INSTALL_DIR/bin:$USR_VENV/bin:$PATH"
 export PYTHONPATH="$INSTALL_DIR/lib/python:$PYTHONPATH"


### PR DESCRIPTION
Make sure neurodamus is installed from the cloned repository and it is not getting the package from pypi.